### PR TITLE
fix bug: can not load proxy contracts's abi

### DIFF
--- a/src/tasks/helpers.ts
+++ b/src/tasks/helpers.ts
@@ -28,12 +28,14 @@ export async function getDeployedContracts(_path: string) {
     if (stat && stat.isFile()) {
       if (file.endsWith(".json")) {
         const name = file.replace(".json", "");
-        const contractJsonFile = fs.readFileSync(filePath, "utf8");
-        const contractJson = JSON.parse(contractJsonFile);
-        const address = contractJson.address;
-        const abi = contractJson.abi;
-        const contract = new ContractInfo(address, filePath, name, abi);
-        contracts.push(contract);
+        if (!name.endsWith("_Proxy")) {
+          const contractJsonFile = fs.readFileSync(filePath, "utf8");
+          const contractJson = JSON.parse(contractJsonFile);
+          const address = contractJson.address;
+          const abi = contractJson.abi;
+          const contract = new ContractInfo(address, filePath, name, abi);
+          contracts.push(contract);
+        }
       }
     }
   }


### PR DESCRIPTION
The reason is that xxx.json is overrided by xxx_Proxy.json. So we should ignore xxx_Proxy.json.